### PR TITLE
Migrate from `pdf-parse` to `unpdf`

### DIFF
--- a/relio/MIGRATION_UNPDF.md
+++ b/relio/MIGRATION_UNPDF.md
@@ -1,0 +1,97 @@
+# Migration to unpdf Library
+
+## Summary
+Successfully migrated from `pdf-parse` to `unpdf` library for PDF text and URL extraction. The unpdf library is a modern, serverless-friendly alternative with better performance and additional features.
+
+## Changes Made
+
+### 1. Dependencies
+- **Removed**: `pdf-parse` (v1.1.1)
+- **Added**: `unpdf` (v1.3.2)
+
+### 2. Code Changes
+
+#### `/src/app/api/upload/route.ts`
+- Replaced `pdfParse` import with `getDocumentProxy`, `extractText` and `extractLinks` from `unpdf`
+- Added URL extraction functionality for PDFs
+- Updated PDF processing to use unpdf's modern API:
+  ```typescript
+  const arrayBuffer = await file.arrayBuffer()
+  const uint8Array = new Uint8Array(arrayBuffer)
+  // Get document proxy first to prevent worker issues in Node.js/Next.js
+  const pdf = await getDocumentProxy(uint8Array)
+  const { text, totalPages } = await extractText(pdf, { mergePages: true })
+  const { links } = await extractLinks(pdf)
+  ```
+- **Important**: 
+  - unpdf requires `Uint8Array` instead of `Buffer`
+  - Must use `getDocumentProxy()` first to avoid DataCloneError in Next.js server environment
+  - Pass the PDF proxy to `extractText()` and `extractLinks()` instead of raw data
+- For DOCX files, convert back to Buffer as mammoth still requires it
+- Enhanced logging to show extracted URLs
+
+#### `/src/lib/ai.ts`
+- Updated `parseResumeToPortfolio` function signature to accept optional URLs array:
+  ```typescript
+  export async function parseResumeToPortfolio(
+    resumeText: string,
+    urls: string[] = []
+  ): Promise<PortfolioConfig>
+  ```
+- Enhanced AI prompt to include URLs found in the PDF for better context:
+  - URLs are now passed to the AI model
+  - AI can use URLs to populate website, LinkedIn, GitHub, and project links
+
+#### `/next.config.ts`
+- Removed `pdf-parse` from `serverComponentsExternalPackages` as unpdf doesn't require it
+
+#### `/src/types/modules.d.ts`
+- Removed TypeScript declarations for `pdf-parse`
+- unpdf has built-in TypeScript support
+
+## Benefits
+
+1. **Better URL Extraction**: Automatically extracts hyperlinks from PDFs
+2. **Serverless Optimized**: unpdf is designed for edge/serverless environments
+3. **Modern API**: Cleaner, promise-based API with TypeScript support
+4. **Enhanced AI Context**: URLs are now included in the AI prompt for better portfolio generation
+5. **Better Maintained**: unpdf is actively maintained (last update 3 days ago)
+6. **Zero Dependencies**: unpdf ships with a serverless build of PDF.js
+
+## Features Added
+
+### URL Extraction
+PDFs now have their embedded URLs automatically extracted and passed to the AI:
+- LinkedIn profiles
+- GitHub repositories
+- Personal websites
+- Project links
+- Any other HTTP/HTTPS URLs
+
+The AI model now receives these URLs and can intelligently assign them to the appropriate fields in the portfolio configuration.
+
+## Testing Recommendations
+
+1. Test PDF upload with embedded URLs (LinkedIn, GitHub, website)
+2. Test PDF without URLs to ensure backward compatibility
+3. Test DOCX files to ensure they still work (no changes to DOCX processing)
+4. Verify that extracted URLs appear correctly in the generated portfolio
+
+## Common Issues & Solutions
+
+### DataCloneError: Cannot transfer object of unsupported type
+**Problem**: This error occurs when unpdf tries to use web workers in Next.js server environment.
+
+**Solution**: Always use `getDocumentProxy()` first, then pass the proxy to `extractText()` and `extractLinks()`:
+```typescript
+const pdf = await getDocumentProxy(uint8Array)
+const { text } = await extractText(pdf, { mergePages: true })
+```
+
+Do NOT pass raw `Uint8Array` directly to `extractText()` in Next.js server routes.
+
+## Notes
+
+- The `unpdf` library uses Mozilla's PDF.js under the hood
+- It includes a serverless-optimized build that works in Node.js, browsers, and edge environments
+- URL extraction only works for PDFs (DOCX files continue to work as before, but without URL extraction)

--- a/relio/README.md
+++ b/relio/README.md
@@ -20,7 +20,7 @@
 - **Database**: PostgreSQL with Prisma ORM
 - **Authentication**: NextAuth.js (Google, GitHub, Credentials)
 - **AI**: Cerebras Cloud SDK for resume parsing
-- **File Parsing**: pdf-parse, mammoth (PDF/DOCX support)
+- **File Parsing**: unpdf (PDF text & URL extraction), mammoth (DOCX support)
 - **Deployment**: Vercel (recommended)
 
 ## 📋 Prerequisites

--- a/relio/bun.lock
+++ b/relio/bun.lock
@@ -21,7 +21,6 @@
         "next": "15.5.4",
         "next-auth": "^4.24.11",
         "ogl": "^1.0.11",
-        "pdf-parse": "^1.1.1",
         "postprocessing": "^6.37.8",
         "prisma": "^6.16.3",
         "radix-ui": "^1.4.3",
@@ -31,6 +30,7 @@
         "tailwind-merge": "^3.3.1",
         "three": "^0.180.0",
         "unique-names-generator": "^4.7.1",
+        "unpdf": "^1.3.2",
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1204,8 +1204,6 @@
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
-    "node-ensure": ["node-ensure@0.0.0", "", {}, "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw=="],
-
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
@@ -1293,8 +1291,6 @@
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "pdf-parse": ["pdf-parse@1.1.1", "", { "dependencies": { "debug": "^3.1.0", "node-ensure": "^0.0.0" } }, "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A=="],
 
     "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
 
@@ -1554,6 +1550,8 @@
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
+    "unpdf": ["unpdf@1.3.2", "", { "peerDependencies": { "@napi-rs/canvas": "^0.1.69" }, "optionalPeers": ["@napi-rs/canvas"] }, "sha512-TWh+7yNL4K9Rn3sjTTMjHhBNxXsrtvIw/nEdYWzLyJU9SZ33s2BhoCSNRG+aUhm/KkdMO6/WK8U6NqRw7fSF4A=="],
+
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
@@ -1695,8 +1693,6 @@
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
-    "pdf-parse/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 

--- a/relio/next.config.ts
+++ b/relio/next.config.ts
@@ -2,9 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  experimental: {
-    serverComponentsExternalPackages: ["pdf-parse"],
-  },
   images: {
     remotePatterns: [
       {

--- a/relio/package.json
+++ b/relio/package.json
@@ -26,7 +26,6 @@
     "next": "15.5.4",
     "next-auth": "^4.24.11",
     "ogl": "^1.0.11",
-    "pdf-parse": "^1.1.1",
     "postprocessing": "^6.37.8",
     "prisma": "^6.16.3",
     "radix-ui": "^1.4.3",
@@ -35,7 +34,8 @@
     "react-dropzone": "^14.3.8",
     "tailwind-merge": "^3.3.1",
     "three": "^0.180.0",
-    "unique-names-generator": "^4.7.1"
+    "unique-names-generator": "^4.7.1",
+    "unpdf": "^1.3.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/relio/src/app/dashboard/edit/page.tsx
+++ b/relio/src/app/dashboard/edit/page.tsx
@@ -761,6 +761,9 @@ function EditPortfolioContent() {
                           onChange={(e) => updateProject(index, 'link', e.target.value)}
                           placeholder="https://project-url.com"
                         />
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Live demo or deployment URL only. Leave empty if no live link exists.
+                        </p>
                       </div>
                       <div>
                         <label className="block text-sm font-medium text-foreground mb-2">GitHub Link (Optional)</label>
@@ -769,6 +772,9 @@ function EditPortfolioContent() {
                           onChange={(e) => updateProject(index, 'github', e.target.value)}
                           placeholder="https://github.com/username/repo"
                         />
+                        <p className="text-xs text-muted-foreground mt-1">
+                          GitHub repository URL
+                        </p>
                       </div>
                     </div>
                   </div>

--- a/relio/src/lib/ai.ts
+++ b/relio/src/lib/ai.ts
@@ -112,9 +112,11 @@ const portfolioSchema = {
 }
 
 export async function parseResumeToPortfolio(
-  resumeText: string
+  resumeText: string,
+  urls: string[] = []
 ): Promise<PortfolioConfig> {
   try {
+    console.log('Parsing resume with Cerebras...')
     const response = await client.chat.completions.create({
       model: 'llama3.3-70b',
       messages: [
@@ -171,7 +173,7 @@ export async function parseResumeToPortfolio(
         },
         {
           role: 'user',
-          content: `Parse this resume and extract the information. Remember: skills MUST be a flat array of strings, not nested objects.\n\nResume:\n${resumeText}`,
+          content: `Parse this resume and extract the information. Remember: skills MUST be a flat array of strings, not nested objects.${urls.length > 0 ? `\n\nURLs found in the document (use these for website, linkedin, github, project links as appropriate):\n${urls.join('\n')}` : ''}\n\nResume:\n${resumeText}`,
         },
       ],
       response_format: {

--- a/relio/src/lib/ai.ts
+++ b/relio/src/lib/ai.ts
@@ -169,7 +169,16 @@ export async function parseResumeToPortfolio(
           - Extract ALL programming languages, frameworks, tools, and technologies into the skills array
           - Format dates as "MMM YYYY" (e.g., "Jan 2020") or just year
           - If a field is missing, omit it (except required fields)
-          - For 'about', create a compelling 2-3 sentence summary if not in resume`,
+          - For 'about', create a compelling 2-3 sentence summary if not in resume
+          
+          PROJECT LINKS RULES:
+          - For projects, use the "name" field for the actual project name ONLY
+          - Do NOT put URLs in the "name" field
+          - Use the "link" field for live demo/deployment URLs (e.g., https://myapp.com)
+          - Use the "github" field for GitHub repository URLs
+          - If there is no live link or deployment URL for a project, leave "link" field empty/omitted
+          - Do NOT duplicate the same URL in both "name" and "link" fields
+          - Do NOT use GitHub URLs in the "link" field - those belong in the "github" field`,
         },
         {
           role: 'user',

--- a/relio/src/types/modules.d.ts
+++ b/relio/src/types/modules.d.ts
@@ -1,16 +1,3 @@
-declare module 'pdf-parse' {
-  interface PDFData {
-    text: string
-    numpages: number
-    info: any
-    metadata: any
-    version: string
-  }
-
-  function pdfParse(buffer: Buffer): Promise<PDFData>
-  export = pdfParse
-}
-
 declare module 'mammoth' {
   interface Result {
     value: string


### PR DESCRIPTION
This pull request migrates the application from using the `pdf-parse` library to the more modern `unpdf` library for PDF parsing. The migration brings enhanced PDF text extraction, automatic URL extraction, and improved compatibility with serverless environments. The AI resume parsing workflow is updated to utilize the extracted URLs, improving portfolio generation accuracy. Several files and dependencies are updated to reflect these changes.

**PDF Parsing and AI Integration Improvements:**

* Replaced `pdf-parse` with `unpdf` for PDF processing in `route.ts`, enabling both text and URL extraction from uploaded PDFs. The code now uses `getDocumentProxy`, `extractText`, and `extractLinks` from `unpdf`, and ensures compatibility with serverless/Next.js environments. For DOCX files, the workflow remains unchanged but ensures compatibility by converting data back to `Buffer` as required by `mammoth`. [[1]](diffhunk://#diff-da2a985511f59a992afcc8f587ee603504afa845c1b5d79f067e0916ef4f0f3fL7-R7) [[2]](diffhunk://#diff-da2a985511f59a992afcc8f587ee603504afa845c1b5d79f067e0916ef4f0f3fL45-L63)
* Enhanced the AI resume parsing (`parseResumeToPortfolio` in `ai.ts`) to accept an optional URLs array, passing extracted URLs to the AI model for improved context. The AI prompt is updated to use these URLs for more accurate portfolio fields (e.g., website, LinkedIn, GitHub, project links). [[1]](diffhunk://#diff-1bdff07ea98305307920f8d991044ed5986aaec2ab041511a31d0ba21d3264e1L115-R119) [[2]](diffhunk://#diff-1bdff07ea98305307920f8d991044ed5986aaec2ab041511a31d0ba21d3264e1L170-R185) [[3]](diffhunk://#diff-da2a985511f59a992afcc8f587ee603504afa845c1b5d79f067e0916ef4f0f3fL79-R93)

**Dependency and Configuration Updates:**

* Removed `pdf-parse` from dependencies and configuration, and added `unpdf` to `package.json` and documentation. Updated `next.config.ts` to remove `pdf-parse` from `serverComponentsExternalPackages`. [[1]](diffhunk://#diff-5199e35bcb2a5f86e3f5cf0dd211ac0b364f570bc2a1287e98690e7410e0994eL29) [[2]](diffhunk://#diff-5199e35bcb2a5f86e3f5cf0dd211ac0b364f570bc2a1287e98690e7410e0994eL38-R38) [[3]](diffhunk://#diff-cce733677265b99eef2b5a43f3e7ffe6ba250939ac5cb06d44c267c743a9dacfL5-L7) [[4]](diffhunk://#diff-2f4ece1258054b417b8e7e79d6ac473e8aa3a5248595cb215196202d4d91fbabL23-R23)

**Documentation and Migration Guide:**

* Added a comprehensive migration guide (`MIGRATION_UNPDF.md`) detailing the migration process, benefits, features, and testing recommendations for the switch to `unpdf`.

**UI/UX Improvements:**

* Updated project link and GitHub link fields in the dashboard editor to provide clearer user instructions about what URLs to enter. [[1]](diffhunk://#diff-f31bde2f59eb6325fa5124322c82541f1c6d250b944fc00b0fa977672e573522R764-R766) [[2]](diffhunk://#diff-f31bde2f59eb6325fa5124322c82541f1c6d250b944fc00b0fa977672e573522R775-R777)